### PR TITLE
Added date format with %Y (e.g. 2021) found in my WhatsApp exports.

### DIFF
--- a/whatsapp2md.py
+++ b/whatsapp2md.py
@@ -66,6 +66,7 @@ def parse_timestamp(line: str) -> Tuple[Optional[datetime], str]:
     datetime_formats = [
         '%d/%m/%y %H:%M ',
         '%d/%m/%y, %H:%M ',
+        '%d/%m/%Y, %H:%M ',
         '%Y-%m-%d, %H:%M ',
     ]
 


### PR DESCRIPTION
My chat exports have the format
```
05/10/2020, 00:14 - Stefan Heimersheim: Sure
```
so I added
```
        '%d/%m/%y, %H:%M ',
```
to the `datetime_formats`.

Thank you for making this tool, it's great!